### PR TITLE
Update for terraform 10.x

### DIFF
--- a/scripts/basic.sh
+++ b/scripts/basic.sh
@@ -17,10 +17,11 @@ else
     exit 1
 fi
 
-if terraform get -update=true $DIR; then
+if terraform init -backend=false -get=true -get-plugins=true $DIR; then
     printf "$GREEN Dependant modules installed $RESET\n"
+    printf "$GREEN Dependant plugins (for providers) installed $RESET\n"
 else
-    printf "$RED Unable to fetch dependant modules.$RESET\n"
+    printf "$RED Unable to fetch dependant modules/plugins.$RESET\n"
     exit 2
 fi
 


### PR DESCRIPTION
`terraform get` doesn't download "provider plugins" which are required to run validate.

I've updated the script to get modules & plugins but still not be dependent on having the backend initialized as it isn't required to run validate.